### PR TITLE
Change `hostip` to `buildserver`

### DIFF
--- a/boot/install.erb
+++ b/boot/install.erb
@@ -7,7 +7,7 @@ TOTALTIMEOUT 5
 
 LABEL INSTALL
      KERNEL boot/centos7-kernel
-        APPEND initrd=boot/centos7-initrd.img ks=http://<%= hostip %><%= permanent_boot ? "" : "/metalware" %>/ks/<%= kickstart %> network ks.sendmac _ALCES_BASE_HOSTNAME=<%= nodename %> <%= kernelappendoptions %>
+        APPEND initrd=boot/centos7-initrd.img ks=http://<%= buildserver %><%= permanent_boot ? "" : "/metalware" %>/ks/<%= kickstart %> network ks.sendmac _ALCES_BASE_HOSTNAME=<%= nodename %> <%= kernelappendoptions %>
         IPAPPEND 2
 
 LABEL local

--- a/hunter/dhcp.erb
+++ b/hunter/dhcp.erb
@@ -1,7 +1,7 @@
   host <%= nodename %> {
     hardware ethernet <%= hwaddr %>;
     option host-name "<%= nodename %>.prv.<%=domain%>";
-    option routers <%= hostip %>;
+    option routers <%= buildserver %>;
     filename "/pxelinux.0";
     fixed-address <%= fixedaddr %>;
   }

--- a/kickstart/compute.erb
+++ b/kickstart/compute.erb
@@ -24,7 +24,7 @@ timezone  Europe/London
 
 #REPOS
 <%if localmirror%>
-url --url=http://<%=hostip%>/<%=cluster%>/repo/centos/
+url --url=http://<%=buildserver%>/<%=cluster%>/repo/centos/
 <%else%>
 url --url=http://mirror.ox.ac.uk/sites/mirror.centos.org/7/os/x86_64/
 <%end%>
@@ -93,12 +93,12 @@ exec 1>/root/ks-post.log 2>&1
 
 mkdir /root/deployment/
 cd /root/deployment
-curl http://<%= hostip %>/metalware/scripts/`hostname -s`/config > config
+curl http://<%= buildserver %>/metalware/scripts/`hostname -s`/config > config
 export ALCES_PROFILE=compute
 pwd
 . ./config
 run_profile
 
-curl http://<%= hostip %>/metalware/exec/kscomplete.php?name=<%= nodename %>
+curl http://<%= buildserver %>/metalware/exec/kscomplete.php?name=<%= nodename %>
 
 %end

--- a/scripts/config
+++ b/scripts/config
@@ -5,7 +5,7 @@
 
 export _ALCES_BASE_HOSTNAME=<%=nodename%>
 
-#infra,comppute
+#infra,compute
 export _ALCES_PROFILE=<%=profile%>
 export _ALCES_BUILDSERVER=<%=buildserver%>
 export _ALCES_BUILDSERVEREXTERNALDNS=mycluster.mydomain.com #Used when configuring external facing http services (This must be live in your site DNS)
@@ -67,7 +67,7 @@ export _ALCES_BMCCHANNEL=1
 export _ALCES_BMCUSER=2
 
 
-#Get Kennel cmdline options
+# Get Kernel cmdline options
 params=`cat /proc/cmdline`
 # Split them on spaces
 params_split=(${params// / })


### PR DESCRIPTION
As suggested by @ste78, as this is a more robust way of determining where nodes should build from, and we apparently plan to phase out usage of `hostip`. See https://alces.slack.com/archives/C0KCX7BNY/p1492083666469364.

Assuming you want this change committed; this appears to work fine afaics (so long as the correct `buildserver` value is set).